### PR TITLE
End of round obstacles are cleaned up

### DIFF
--- a/Bullet.gd
+++ b/Bullet.gd
@@ -7,3 +7,7 @@ var topSpeed = 25
 func _process(delta):
 	var velocity = Vector2(speed, 0).rotated(self.rotation)
 	self.linear_velocity = velocity.rotated(self.rotation)
+
+
+func _on_VisibilityNotifier2D_viewport_exited(viewport):
+	queue_free()

--- a/Bullet.tscn
+++ b/Bullet.tscn
@@ -6,7 +6,9 @@
 [sub_resource type="CircleShape2D" id=1]
 radius = 84.5351
 
-[node name="Bullet" type="RigidBody2D"]
+[node name="Bullet" type="RigidBody2D" groups=[
+"bullets",
+]]
 collision_mask = 0
 gravity_scale = 0.0
 script = ExtResource( 2 )
@@ -18,3 +20,7 @@ texture = ExtResource( 1 )
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 scale = Vector2( 0.33, 0.33 )
 shape = SubResource( 1 )
+
+[node name="VisibilityNotifier2D" type="VisibilityNotifier2D" parent="."]
+
+[connection signal="viewport_exited" from="VisibilityNotifier2D" to="." method="_on_VisibilityNotifier2D_viewport_exited"]

--- a/HellSpawn.gd
+++ b/HellSpawn.gd
@@ -9,6 +9,7 @@ func _ready():
 	$Timer.set_wait_time(timerCount)
 	$Timer.start()
 	disabled = true
+	hide()
 	
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -37,3 +38,4 @@ func _on_Timer_timeout():
 
 func start():
 	disabled = false
+	show()

--- a/Main.gd
+++ b/Main.gd
@@ -18,6 +18,7 @@ func game_over():
 
 func new_game():
 	get_tree().call_group("mobs", "queue_free")
+	get_tree().call_group("bullets", "queue_free")
 	score = 0
 	$Player.start($StartPosition.position)
 	$StartTimer.start()


### PR DESCRIPTION
* `queue_free` on all bullets after round ends
* `hide()` the hellspawn before game start and `show()` on start